### PR TITLE
update database.py distro detection

### DIFF
--- a/modoboa_installer/database.py
+++ b/modoboa_installer/database.py
@@ -1,7 +1,7 @@
 """Database related tools."""
 
 import os
-import platform
+import distro
 import pwd
 import stat
 
@@ -143,7 +143,7 @@ class MySQL(Database):
 
     def install_package(self):
         """Preseed package installation."""
-        name, version, _id = platform.linux_distribution()
+        name, version, _id = distro.linux_distribution()
         name = name.lower()
         if name == "debian":
             mysql_name = "mysql" if version.startswith("8") else "mariadb"


### PR DESCRIPTION
platform module is deprecated beginning with Python 3.7. 
So distro module should be used instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
